### PR TITLE
Update com.ranfdev.Lobjur.json

### DIFF
--- a/com.ranfdev.Lobjur.json
+++ b/com.ranfdev.Lobjur.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.ranfdev.Lobjur",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "lobjur",
     "finish-args": [


### PR DESCRIPTION
The GNOME 44 runtime is no longer supported as of March 20, 2024